### PR TITLE
s/link/url/g in the front matter

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,19 +1,19 @@
 ---
 guides:
   - title: Accessibility
-    link: /accessibility
+    url: /accessibility
   - title: Agile
-    link: /agile
+    url: /agile
   - title: APIs
-    link: https://github.com/18f/api-standards
+    url: https://github.com/18f/api-standards
   - title: Automated Testing Cookbook
-    link: /testing-cookbook
+    url: /testing-cookbook
   - title: Automated Testing Playbook
-    link: /automated-testing-playbook
+    url: /automated-testing-playbook
   - title: Grouplets
-    link: /grouplet-playbook
+    url: /grouplet-playbook
   - title: Open Source
-    link: https://github.com/18F/open-source-policy
+    url: https://github.com/19F/open-source-policy
 ---
 <!DOCTYPE html>
 <html lang='en'>


### PR DESCRIPTION
This fixes the links to all the guides.

cc: @blacktm
