### PR TITLE
Adding methods to the guides navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@ guides:
     url: /before-you-ship
   - title: Content
     url: /content-guide
+  - title: Design Method Cards
+    url: https://methods.18f.gov/
   - title: Federalist Content Guide
     url: /federalist-content-guide
   - title: Frontend


### PR DESCRIPTION
Adds the methods guide as "design methods cards" for additional context when doing menu navigation on the Guides page. Unsure if that's the right nomenclature....

@jenniferthibault please feel free to mod
