### PR TITLE
Case fix to prevent 404s

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ exclude:
 
 navigation:
 - text: "18F Delivery: Partnership Playbook"
-  url: /Partnership-Playbook
+  url: /partnership-playbook
 - text: Accessibility
   url: /accessibility
 - text: Analytics


### PR DESCRIPTION
Will changed the case of the repo name (correctly, to lower-case). But now we get 404s as a result. Flipping it here.
