### PR TITLE
Redirect federalist link to comprehensive docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,8 +30,8 @@ navigation:
   url: https://methods.18f.gov/
 - text: Development Environment Guide
   url: https://pages.18f.gov/dev-environment/
-- text: Federalist Content Guide
-  url: /federalist-content-guide
+- text: Federalist Documentation
+  url: https://federalist-docs.18f.gov
 - text: Frontend
   url: /frontend
 - text: Grouplet Playbook


### PR DESCRIPTION
Together with 18F/federalist-content-guide#6 this changes the link for Federalist documentation from the former content guide to the more comprehensive set of docs at [federalist-docs.18f.gov](https://federalist-docs.18f.gov)
