### PR TITLE
Remove guides nav, add guidance for lost pages viewers

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,12 +1,40 @@
----
-guides:
----
-<h1>404: Page not found</h1>
+<!DOCTYPE html>
+<html lang='en'>
 
-<p>If you followed a link to get here, you may be able to find what you were looking for at one of these sites:</p>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta charset="utf-8">
+  <meta property="og:type" content="website" />
 
-<ul>
-	<li><a href="https://pages.18f.gov/guides/">18F Guides</a></li>
-	<li><a href="https://18f.gsa.gov/">The 18F website</a></li>
-	<li><a href="https://18f.gsa.gov/blog/">The 18F blog</a></li>
-</ul>
+  <title>404 File not found</title>
+  <meta property="og:title" content="404 File not found" />
+  <link rel="stylesheet" href="/guides-template/assets/css/styles.css" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:400,400italic,600" rel="stylesheet" type="text/css">
+
+</head>
+
+  <body>
+
+    <div class="container">
+
+        <section id="main" class="wrap" role="main">
+
+			<h1>404: Page not found</h1>
+
+			<p>You may be able to find what you were looking for at one of these sites:</p>
+
+			<ul>
+				<li><a href="https://pages.18f.gov/guides/">18F Guides</a></li>
+				<li><a href="https://18f.gsa.gov/">The 18F website</a></li>
+				<li><a href="https://18f.gsa.gov/blog/">The 18F blog</a></li>
+			</ul>
+
+			<p>If you're looking for an old 18F Pages site, it might not be online anymore, but the content is probably still in a GitHub repository. Try going to the <a href="https://github.com/18F">18F GitHub organization</a> and searching for the name of the old 18F Pages site.</p>
+
+        </section>
+
+    </div> <!-- /.container -->
+
+  </body>
+
+</html>


### PR DESCRIPTION
With some help from @brittag, I've removed the Guides wrapper, which was a little confusing, and added guidance about looking in our GitHub org for lost pages content.