### PR TITLE
Update links to 18F Pages sites to their new 18f.gov subdomain URLs

### DIFF
--- a/404.html
+++ b/404.html
@@ -18,8 +18,8 @@
     <p>You may be able to find what you were looking for at one of these sites:</p>
 
     <ul>
-      <li><a href="https://pages.18f.gov/guides/">18F Guides</a></li>
-      <li><a href="https://18f.gsa.gov/">The 18F website</a></li>
+      <li><a href="https://guides.18f.gov">18F Guides</a></li>
+      <li><a href="https://18f.gsa.gov">The 18F website</a></li>
       <li><a href="https://18f.gsa.gov/blog/">The 18F blog</a></li>
     </ul>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # 18F Guides
 
-[View 18F Guides »](http://pages.18f.gov/guides/)
+[View 18F Guides »](http://guides.18f.gov)

--- a/_config.yml
+++ b/_config.yml
@@ -13,14 +13,12 @@ author:
 navigation:
 - text: Accessibility
   url: https://accessibility.18f.gov
-- text: Analytics
-  url: https://github.com/18F/analytics-standards
 - text: Agile
   url: https://agile.18f.gov
+- text: Analytics
+  url: https://github.com/18F/analytics-standards
 - text: APIs
   url: https://github.com/18f/api-standards
-- text: Testing Cookbook
-  url: https://testing-cookbook.18f.gov
 - text: Automated Testing Playbook
   url: https://automated-testing-playbook.18f.gov
 - text: Before You Ship
@@ -31,9 +29,15 @@ navigation:
   url: https://content-guide.18f.gov
 - text: Design Methods
   url: https://methods.18f.gov
+- text: Design Principles Guide
+  url: https://design-principles-guide.18f.gov
+- text: Digital Acquisition Playbook
+  url: https://digital-acquisition-playbook.18f.gov
+- text: Digital Contracting Cookbook
+  url: https://contracting-cookbook.18f.gov
 - text: Federalist Documentation
   url: https://federalist-docs.18f.gov
-- text: Frontend
+- text: Front End
   url: https://frontend.18f.gov
 - text: Grouplet Playbook
   url: https://grouplet-playbook.18f.gov
@@ -45,12 +49,18 @@ navigation:
   url: https://18f.gsa.gov/join/
 - text: Lean Product Design
   url: https://lean-product-design.18f.gov
+- text: Modular Contracting
+  url: http://modularcontracting.18f.gov
 - text: Open Source Guide
   url: https://open-source-guide.18f.gov
 - text: Partnership Playbook
   url: https://partnership-playbook.18f.gov
+- text: Plain Language Tutorial
+  url: https://plain-language-tutorial.18f.gov
 - text: Product
   url: https://product-guide.18f.gov
+- text: Testing Cookbook
+  url: https://testing-cookbook.18f.gov
 - text: Writing Lab
   url: https://writing-lab-guide.18f.gov
 

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,10 @@ exclude:
 - README.md
 - LICENSE.md
 
+author:
+  name: 18F
+  url: https://18f.gsa.gov
+
 navigation:
 - text: Accessibility
   url: https://accessibility.18f.gov

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ exclude:
 
 navigation:
 - text: Accessibility
-  url: https://pages.18f.gov/accessibility
+  url: https://accessibility.18f.gov
 - text: Analytics
   url: https://github.com/18F/analytics-standards
 - text: Agile
@@ -16,41 +16,39 @@ navigation:
 - text: APIs
   url: https://github.com/18f/api-standards
 - text: Testing Cookbook
-  url: https://pages.18f.gov/testing-cookbook
+  url: https://testing-cookbook.18f.gov
 - text: Automated Testing Playbook
-  url: https://pages.18f.gov/automated-testing-playbook
+  url: https://automated-testing-playbook.18f.gov
 - text: Before You Ship
-  url: https://pages.18f.gov/before-you-ship
+  url: https://before-you-ship.18f.gov
 - text: Blogging
-  url: https://pages.18f.gov/blogging-guide
+  url: https://blogging-guide.18f.gov
 - text: Content Guide
-  url: https://pages.18f.gov/content-guide
+  url: https://content-guide.18f.gov
 - text: Design Methods
-  url: https://methods.18f.gov/
-- text: Development Environment Guide
-  url: https://pages.18f.gov/dev-environment/
+  url: https://methods.18f.gov
 - text: Federalist Documentation
   url: https://federalist-docs.18f.gov
 - text: Frontend
-  url: https://pages.18f.gov/frontend
+  url: https://frontend.18f.gov
 - text: Grouplet Playbook
-  url: https://pages.18f.gov/grouplet-playbook
+  url: https://grouplet-playbook.18f.gov
 - text: Guides Template
-  url: https://pages.18f.gov/guides-template
+  url: https://guides-template.18f.gov
 - text: Inter-Agency Agreements with 18F
-  url: https://pages.18f.gov/iaa-forms
-- text: Joining 18F!
-  url: https://pages.18f.gov/joining-18f
+  url: https://iaa-forms.18f.gov
+- text: Joining 18F
+  url: https://18f.gsa.gov/join/
 - text: Lean Product Design
-  url: https://pages.18f.gov/lean-product-design
+  url: https://lean-product-design.18f.gov
 - text: Open Source Guide
-  url: https://pages.18f.gov/open-source-guide
+  url: https://open-source-guide.18f.gov
 - text: Partnership Playbook
-  url: https://pages.18f.gov/partnership-playbook
+  url: https://partnership-playbook.18f.gov
 - text: Product
-  url: https://pages.18f.gov/product-guide
+  url: https://product-guide.18f.gov
 - text: Writing Lab
-  url: https://pages.18f.gov/writing-lab-guide
+  url: https://writing-lab-guide.18f.gov
 
 
 google_analytics_ua: UA-48605964-19

--- a/index.html
+++ b/index.html
@@ -13,4 +13,4 @@ we hope to encourage expert review and contributions from members of the tech co
 furthering our goal of improving how government works through increased civic engagement of tech specialists.</p>
 
 <p>To create a new 18F Guide, or to update an existing guide to the 18F Guide format,
-see the <a href="https://pages.18f.gov/guides-template/">18F Guides template</a>.</p>
+see the <a href="https://guides-template.18f.gov">18F Guides template</a>.</p>


### PR DESCRIPTION
This PR updates all `pages.18f.gov/<PAGE>` links in this repo's content to their new URLs of the form `<PAGE>.18f.gov`.

In addition, it 
- Removes the link to [Development Environment Guide](https://pages.18f.gov/dev-environment/) because that guide will not be migrated and will thus soon be taken down.
- Adds the `author` config to `_config.yml` in order to fix the missing content in the footer of the site.
