### PR TITLE
[WIP] Update guides_style_18f

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,12 @@
 source 'https://rubygems.org/'
 
-gem 'jekyll'
+# We are pinning to this version of jekyll because of problems with the
+# search plugin that is required as part of guides_style_18f.
+# For background, see https://github.com/18F/guides-style/issues/84 and
+# https://github.com/18F/jekyll_pages_api_search/issues/37
+# This is especially unfortunate because we don't even use the search
+# functionality as part of this guide.
+gem 'jekyll', '~> 3.1.0'
 
 group :jekyll_plugins do
   gem 'guides_style_18f'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,78 +1,53 @@
 GEM
+  remote: https://rubygems.org/
   specs:
-    blankslate (2.1.2.4)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
-    classifier-reborn (2.0.3)
-      fast-stemmer (~> 1.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.9.1.1)
     colorator (0.1)
-    execjs (2.5.2)
-    fast-stemmer (1.0.2)
-    ffi (1.9.8)
-    guides_style_18f (0.0.1)
-      jekyll (~> 2.5)
-      rouge (~> 1.9)
-      sass (~> 3.4)
-    hitimes (1.2.2)
-    jekyll (2.5.3)
-      classifier-reborn (~> 2.0)
+    ffi (1.9.18)
+    guides_style_18f (1.0.2)
+      jekyll
+      jekyll_pages_api
+      jekyll_pages_api_search
+      rouge
+      sass
+    htmlentities (4.3.4)
+    jekyll (3.1.6)
       colorator (~> 0.1)
-      jekyll-coffeescript (~> 1.0)
-      jekyll-gist (~> 1.0)
-      jekyll-paginate (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
-      liquid (~> 2.6.1)
+      liquid (~> 3.0)
       mercenary (~> 0.3.3)
-      pygments.rb (~> 0.6.0)
-      redcarpet (~> 3.1)
+      rouge (~> 1.7)
       safe_yaml (~> 1.0)
-      toml (~> 0.1.0)
-    jekyll-coffeescript (1.0.1)
-      coffee-script (~> 2.2)
-    jekyll-gist (1.2.1)
-    jekyll-paginate (1.1.0)
-    jekyll-sass-converter (1.3.0)
-      sass (~> 3.2)
-    jekyll-watch (1.2.1)
-      listen (~> 2.7)
-    kramdown (1.7.0)
-    liquid (2.6.2)
-    listen (2.10.0)
-      celluloid (~> 0.16.0)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    mercenary (0.3.5)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
-    posix-spawn (0.3.11)
-    pygments.rb (0.6.3)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
-    rb-fsevent (0.9.4)
-    rb-inotify (0.9.5)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    jekyll_pages_api (0.1.6)
+      htmlentities (~> 4.3)
+      jekyll (>= 2.0, < 4.0)
+    jekyll_pages_api_search (0.4.4)
+      jekyll_pages_api (~> 0.1.4)
+      sass (~> 3.4)
+    kramdown (1.13.2)
+    liquid (3.0.6)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
-    redcarpet (3.2.3)
-    rouge (1.9.1)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.13)
-    timers (4.0.1)
-      hitimes
-    toml (0.1.2)
-      parslet (~> 1.5.0)
-    yajl-ruby (1.2.1)
+    sass (3.4.24)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   guides_style_18f
-  jekyll
+  jekyll (~> 3.1.0)
 
 BUNDLED WITH
-   1.10.6
+   1.15.0

--- a/_config.yml
+++ b/_config.yml
@@ -76,6 +76,9 @@ back_link:
   url: "https://18f.gsa.gov/"
   text: Back to 18F Homepage
 
+# TODO: Update this to "master"
+default_branch: "18f-pages"
+
 defaults:
   -
     scope:

--- a/index.html
+++ b/index.html
@@ -1,12 +1,11 @@
 ---
 guides:
+title: 18F Guides
 ---
-<h1>18F Guides</h1>
-
 <p>18F Guides is the repository for best practices across our teams.
 Our guides are open source, and you're free to use them as you wish.
 Our hope is that other digital service teams — both inside and outside the government —
-will adopt or modify the practices outlined here. </p>
+will adopt or modify the practices outlined here.</p>
 
 <p>By developing this material in the open,
 we hope to encourage expert review and contributions from members of the tech community,


### PR DESCRIPTION
- Pin jekyll to 3.1.0 so `jekyll_pages_api_search` plugin doesn't break the jekyll build.

To Do:
- [ ] `search-bundle.js` is missing and causing a `404` error on the index page now. We don't even need search on this site, so need to figure out how to disable it. Or maybe just include it so it doesn't `404`. Barf.