### PR TITLE
Remove the blogging guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,8 +23,6 @@ navigation:
   url: https://automated-testing-playbook.18f.gov
 - text: Before You Ship
   url: https://before-you-ship.18f.gov
-- text: Blogging
-  url: https://blogging-guide.18f.gov
 - text: Content Guide
   url: https://content-guide.18f.gov
 - text: Design Methods


### PR DESCRIPTION
Blogging guide is now part of the [Handbook](https://handbook.18f.gov/blogging/)